### PR TITLE
[EPAY-12585] Add macOS x86-64 support

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -15,7 +15,7 @@ when /x86_64.*linux/
 when /linux/
   'linux_x86'
 when /darwin/
-  'darwin_x86'
+  RbConfig::CONFIG['host_cpu'] == 'x86_64' ? 'darwin_amd64' : 'darwin_x86'
 else
   raise "Invalid platform. Must be running on linux or intel-based Mac OS."
 end


### PR DESCRIPTION
Added the x86-64 binary from the 0.12.1 installer package, unmodified,
and the version selector code from the newer gem versions.